### PR TITLE
Fix to broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 This is meant to be a standalone server, but at the moment it is
 coupled with the go-livepeer repo. For the time being development will
 proceed at the
-[github.com/livepeer/go-livepeer/lpms package](https://github.com/livepeer/go-livepeer/lpms).
+[github.com/livepeer/go-livepeer/lpms package](https://github.com/livepeer/go-livepeer/tree/master/lpms).


### PR DESCRIPTION
Current link in readme returns 404. Updated the link to point to tree/master. Would be nicer if you could use a [relative link to automatically point to whatever the current branch](https://github.com/blog/1395-relative-links-in-markup-files) is, but don't see a way to do that since this link crosses repos.